### PR TITLE
Added AES CBC encryption with key derives from random uuid with salt …

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Features:
 - browser history is used while editing for easy undo;
 - edit history is also saved in the database: after you load the data,
   previous version of the data is available by clicking the "back" button in bottom right corner;
+- Added Encryption option to encrypt data in browser before inserting into ClickHouse database,
+  encryption key is kept in anchor tag which never leaves the user's browser.
 
 ## Motivation
 

--- a/index.html
+++ b/index.html
@@ -100,6 +100,7 @@
 <a class="about" href="https://github.com/ClickHouse/pastila">About</a>
 <div class="encryption">
     <input id="encryption" checked=true type="checkbox">AES Encryption</input> 
+    <input id="passwordfield" type="password" placeholder="password"></input> 
 </div>
 <span class="status" id="hourglass">⧗</span>
 <span class="status" id="check-mark">✔</span>
@@ -192,6 +193,7 @@ let error = document.getElementById('error');
 let wait = document.getElementById('hourglass');
 let encryption = document.getElementById('encryption');
 
+
 function hide() {
     back.style.display = 'none';
     check.style.display = 'none';
@@ -231,11 +233,12 @@ function base64ToBytes(base64) {
 
 async function decrypt(content){
     try {
+        let userpassword = passwordfield.value;
         if (anchorkey == '') {
             throw "No key was found - cannot decrypt";
         }
         let encryptedbytes=base64ToBytes(content.substr(4));
-        const encodedkey = new TextEncoder('utf8').encode(anchorkey);
+        const encodedkey = new TextEncoder('utf8').encode(userpassword+anchorkey);
         pbkdf2_keymaterials = await window.crypto.subtle.importKey("raw", encodedkey, {name: "PBKDF2"}, false, ["deriveBits"]);
         const salt = encryptedbytes.slice(8, 16);
         let pbkdf2keybytes = await window.crypto.subtle.deriveBits({ "name": 'PBKDF2', "salt": salt, "iterations": 1000, "hash": 'SHA-256' }, pbkdf2_keymaterials, 384);
@@ -256,11 +259,12 @@ async function decrypt(content){
 
 async function encrypt(content){
     try {
+        let userpassword = passwordfield.value;
         if (anchorkey == '') {
             anchorkey=([1e7]+-1e3+-4e3+-8e3+-1e11).replace(/[018]/g, c =>(c ^ crypto.getRandomValues(new Uint8Array(1))[0] & 15 >> c / 4).toString(16));
         }
         let plaintextbytes = new TextEncoder("utf-8").encode(content);
-        const encodedkey = new TextEncoder('utf8').encode(anchorkey);
+        const encodedkey = new TextEncoder('utf8').encode(userpassword+anchorkey);
         pbkdf2_keymaterials = await window.crypto.subtle.importKey("raw", encodedkey, {name: "PBKDF2"}, false, ["deriveBits"]);
         salt = window.crypto.getRandomValues(new Uint8Array(8));
         let pbkdf2keybytes = await window.crypto.subtle.deriveBits({ "name": 'PBKDF2', "salt": salt, "iterations": 1000, "hash": 'SHA-256' }, pbkdf2_keymaterials, 384);
@@ -340,6 +344,8 @@ async function load(fingerprint, hash, type) {
 
     setFavicon();
 }
+
+document.getElementById('passwordfield').addEventListener('input', (event) => restore());
 
 async function save(text) {
     const my_request_num = ++request_num;

--- a/index.html
+++ b/index.html
@@ -347,7 +347,12 @@ async function load(fingerprint, hash, type) {
     setFavicon();
 }
 
-passwordfield.addEventListener('input', (event) => restore());
+passwordfield.addEventListener('keyup', (event) => {
+    if (event.key === 'Enter' || event.keyCode === 13) 
+        restore()
+    });
+
+passwordfield.addEventListener('focusout', (event) =>restore());
 
 async function save(text) {
     const my_request_num = ++request_num;

--- a/index.html
+++ b/index.html
@@ -192,7 +192,9 @@ let check = document.getElementById('check-mark');
 let error = document.getElementById('error');
 let wait = document.getElementById('hourglass');
 let encryption = document.getElementById('encryption');
-
+let passwordfield = document.getElementById('passwordfield');
+passwordfield.addEventListener("mouseover",()=>{event.target.type = 'text'});
+passwordfield.addEventListener("mouseout",()=>{event.target.type = 'password'});
 
 function hide() {
     back.style.display = 'none';
@@ -316,7 +318,7 @@ async function load(fingerprint, hash, type) {
 
     if (content.startsWith("Enc=")) {
         encryption.checked = true;
-        encryption.setAttribute('disabled','')
+        encryption.setAttribute('disabled','');
         content = await decrypt(content);
         if (content === "") {
             document.getElementById('data').value = "Fail to decrypt content - Do you have the key?";
@@ -345,7 +347,7 @@ async function load(fingerprint, hash, type) {
     setFavicon();
 }
 
-document.getElementById('passwordfield').addEventListener('input', (event) => restore());
+passwordfield.addEventListener('input', (event) => restore());
 
 async function save(text) {
     const my_request_num = ++request_num;
@@ -414,6 +416,8 @@ async function savedata(event){
             console.log("Fail to encrypt");
             return;
         }
+        encryption.setAttribute('disabled','');
+        passwordfield.setAttribute('disabled','');
     }
 
     curr_hash = sipHash128(encoder.encode(text));

--- a/index.html
+++ b/index.html
@@ -100,7 +100,7 @@
 <a class="about" href="https://github.com/ClickHouse/pastila">About</a>
 <div class="encryption">
     <input id="encryption" checked=true type="checkbox">AES Encryption</input> 
-    <input id="passwordfield" type="password" placeholder="password"></input> 
+    <input id="passwordfield" type="password" placeholder="password" style="display:none"></input> 
 </div>
 <span class="status" id="hourglass">⧗</span>
 <span class="status" id="check-mark">✔</span>
@@ -239,7 +239,7 @@ async function decrypt(content){
         if (anchorkey == '') {
             throw "No key was found - cannot decrypt";
         }
-        let encryptedbytes=base64ToBytes(content.substr(4));
+        let encryptedbytes=base64ToBytes(content);
         const encodedkey = new TextEncoder('utf8').encode(userpassword+anchorkey);
         pbkdf2_keymaterials = await window.crypto.subtle.importKey("raw", encodedkey, {name: "PBKDF2"}, false, ["deriveBits"]);
         const salt = encryptedbytes.slice(8, 16);
@@ -280,7 +280,7 @@ async function encrypt(content){
         resultbytes.set(new TextEncoder("utf-8").encode('Salted__'));
         resultbytes.set(salt, 8);
         resultbytes.set(encryptedbytes, 16);
-        result = "Enc="+bytesToBase64(resultbytes);
+        result = bytesToBase64(resultbytes);
         return result;
 
     } catch (e) {
@@ -296,7 +296,7 @@ async function load(fingerprint, hash, type) {
 
     const response = await fetch(
         clickhouse_url,
-        { method: "POST", body: `SELECT content, lower(hex(reinterpretAsFixedString(prev_hash))) AS prev_hash, lower(hex(reinterpretAsFixedString(prev_fingerprint))) AS prev_fingerprint FROM data WHERE fingerprint = reinterpretAsUInt32(unhex('${fingerprint}')) AND hash = reinterpretAsUInt128(unhex('${hash}')) ORDER BY time LIMIT 1 FORMAT JSON` });
+        { method: "POST", body: `SELECT content, is_encrypted, lower(hex(reinterpretAsFixedString(prev_hash))) AS prev_hash, lower(hex(reinterpretAsFixedString(prev_fingerprint))) AS prev_fingerprint FROM data WHERE fingerprint = reinterpretAsUInt32(unhex('${fingerprint}')) AND hash = reinterpretAsUInt128(unhex('${hash}')) ORDER BY time LIMIT 1 FORMAT JSON` });
 
     function onError() {
         show(error);
@@ -309,6 +309,7 @@ async function load(fingerprint, hash, type) {
 
     const result = json.data[0];
     let content = result.content;
+    const is_encrypted = result.is_encrypted;
 
     prev_hash = result.prev_hash;
     prev_fingerprint = result.prev_fingerprint;
@@ -316,7 +317,7 @@ async function load(fingerprint, hash, type) {
     curr_hash = hash;
     curr_fingerprint = fingerprint;
 
-    if (content.startsWith("Enc=")) {
+    if (is_encrypted) {
         encryption.checked = true;
         encryption.setAttribute('disabled','');
         content = await decrypt(content);
@@ -354,7 +355,7 @@ passwordfield.addEventListener('keyup', (event) => {
 
 passwordfield.addEventListener('focusout', (event) =>restore());
 
-async function save(text) {
+async function save(text, is_encrypted) {
     const my_request_num = ++request_num;
 
     show(wait);
@@ -363,13 +364,14 @@ async function save(text) {
         clickhouse_url,
         {
             method: "POST",
-            body: "INSERT INTO data (fingerprint_hex, hash_hex, prev_fingerprint_hex, prev_hash_hex, content) FORMAT JSONEachRow " + JSON.stringify(
+            body: "INSERT INTO data (fingerprint_hex, hash_hex, prev_fingerprint_hex, prev_hash_hex, content, is_encrypted) FORMAT JSONEachRow " + JSON.stringify(
             {
                 fingerprint_hex: curr_fingerprint,
                 hash_hex: curr_hash,
                 prev_fingerprint_hex: prev_fingerprint,
                 prev_hash_hex: prev_hash,
-                content: text
+                content: text,
+                is_encrypted: is_encrypted
             })
         });
 
@@ -412,10 +414,12 @@ function loadMarkdownRenderer() {
 
 async function savedata(event){
     prev_fingerprint = curr_fingerprint;
-    prev_hash = curr_hash
+    prev_hash = curr_hash;
+    is_encrypted = false;
 
     let text = document.getElementById('data').value;
     if (encryption.checked == true) {
+        is_encrypted=true;
         text = await encrypt(text)
         if (text === ''){
             console.log("Fail to encrypt");
@@ -428,7 +432,7 @@ async function savedata(event){
     curr_hash = sipHash128(encoder.encode(text));
     curr_fingerprint = getFingerprint(text);
 
-    save(text);
+    save(text, is_encrypted);
 }
 
 document.getElementById('data').addEventListener('input', (event) => savedata(event));

--- a/index.html
+++ b/index.html
@@ -99,7 +99,7 @@
 <body>
 <a class="about" href="https://github.com/ClickHouse/pastila">About</a>
 <div class="encryption">
-<input id="encryption"  type="checkbox">AES Encryption</a>
+    <input id="encryption" checked=true type="checkbox">AES Encryption</input> 
 </div>
 <span class="status" id="hourglass">⧗</span>
 <span class="status" id="check-mark">✔</span>
@@ -232,25 +232,25 @@ function base64ToBytes(base64) {
 async function decrypt(content){
     try {
         if (anchorkey == '') {
-            throw "No key was found - cannot decrypt"
+            throw "No key was found - cannot decrypt";
         }
-        let encryptedbytes=base64ToBytes(content.substr(4))
-        const encodedkey = new TextEncoder('utf8').encode(anchorkey)
+        let encryptedbytes=base64ToBytes(content.substr(4));
+        const encodedkey = new TextEncoder('utf8').encode(anchorkey);
         pbkdf2_keymaterials = await window.crypto.subtle.importKey("raw", encodedkey, {name: "PBKDF2"}, false, ["deriveBits"]);
         const salt = encryptedbytes.slice(8, 16);
-        let pbkdf2keybytes = await window.crypto.subtle.deriveBits({ "name": 'PBKDF2', "salt": salt, "iterations": 1000, "hash": 'SHA-256' }, pbkdf2_keymaterials, 384)
+        let pbkdf2keybytes = await window.crypto.subtle.deriveBits({ "name": 'PBKDF2', "salt": salt, "iterations": 1000, "hash": 'SHA-256' }, pbkdf2_keymaterials, 384);
         pbkdf2keybytes = new Uint8Array(pbkdf2keybytes);
         const keybytes = pbkdf2keybytes.slice(0, 32);
         const iv = pbkdf2keybytes.slice(32);
         encryptedbytes = encryptedbytes.slice(16);
-        const aeskey = await window.crypto.subtle.importKey('raw', keybytes, { name: 'AES-CBC', length: 256 }, false, ['decrypt'])
-        let plaintextbytes = await window.crypto.subtle.decrypt({ name: "AES-CBC", iv: iv }, aeskey, encryptedbytes)
-        const result = new TextDecoder("utf-8").decode(plaintextbytes)
-        return result
+        const aeskey = await window.crypto.subtle.importKey('raw', keybytes, { name: 'AES-CBC', length: 256 }, false, ['decrypt']);
+        let plaintextbytes = await window.crypto.subtle.decrypt({ name: "AES-CBC", iv: iv }, aeskey, encryptedbytes);
+        const result = new TextDecoder("utf-8").decode(plaintextbytes);
+        return result;
     } catch(e) {
-        console.log("Fail to decrypt - return content as is")
-        console.log(e)
-        return content
+        console.log("Fail to decrypt - return content as is");
+        console.log(e);
+        return "";
     }
 }
 
@@ -259,28 +259,28 @@ async function encrypt(content){
         if (anchorkey == '') {
             anchorkey=([1e7]+-1e3+-4e3+-8e3+-1e11).replace(/[018]/g, c =>(c ^ crypto.getRandomValues(new Uint8Array(1))[0] & 15 >> c / 4).toString(16));
         }
-        let plaintextbytes = new TextEncoder("utf-8").encode(content)
-        const encodedkey = new TextEncoder('utf8').encode(anchorkey)
+        let plaintextbytes = new TextEncoder("utf-8").encode(content);
+        const encodedkey = new TextEncoder('utf8').encode(anchorkey);
         pbkdf2_keymaterials = await window.crypto.subtle.importKey("raw", encodedkey, {name: "PBKDF2"}, false, ["deriveBits"]);
         salt = window.crypto.getRandomValues(new Uint8Array(8));
-        let pbkdf2keybytes = await window.crypto.subtle.deriveBits({ "name": 'PBKDF2', "salt": salt, "iterations": 1000, "hash": 'SHA-256' }, pbkdf2_keymaterials, 384)
+        let pbkdf2keybytes = await window.crypto.subtle.deriveBits({ "name": 'PBKDF2', "salt": salt, "iterations": 1000, "hash": 'SHA-256' }, pbkdf2_keymaterials, 384);
         pbkdf2keybytes = new Uint8Array(pbkdf2keybytes);
         const keybytes = pbkdf2keybytes.slice(0, 32);
         const iv = pbkdf2keybytes.slice(32);
-        const aeskey = await window.crypto.subtle.importKey('raw', keybytes, { name: 'AES-CBC', length: 256 }, false, ['encrypt'])
-        let encryptedbytes = await window.crypto.subtle.encrypt({ name: "AES-CBC", iv: iv }, aeskey, plaintextbytes)
+        const aeskey = await window.crypto.subtle.importKey('raw', keybytes, { name: 'AES-CBC', length: 256 }, false, ['encrypt']);
+        let encryptedbytes = await window.crypto.subtle.encrypt({ name: "AES-CBC", iv: iv }, aeskey, plaintextbytes);
         encryptedbytes = new Uint8Array(encryptedbytes);
-        let resultbytes = new Uint8Array(encryptedbytes.length + 16)
+        let resultbytes = new Uint8Array(encryptedbytes.length + 16);
         resultbytes.set(new TextEncoder("utf-8").encode('Salted__'));
         resultbytes.set(salt, 8);
         resultbytes.set(encryptedbytes, 16);
-        result = "Enc="+bytesToBase64(resultbytes)
-        return result
+        result = "Enc="+bytesToBase64(resultbytes);
+        return result;
 
     } catch (e) {
-        alert("Fail to encrypt - File not sent")
+        alert("Fail to encrypt - File not sent");
         console.error(e);
-        return ""
+        return "";
     }
 
 }
@@ -311,14 +311,13 @@ async function load(fingerprint, hash, type) {
     curr_fingerprint = fingerprint;
 
     if (content.startsWith("Enc=")) {
-        encryption.checked = true
-        decryptedcontent=await decrypt(content)
-        if (content === decryptedcontent) {
+        encryption.checked = true;
+        encryption.setAttribute('disabled','')
+        content = await decrypt(content);
+        if (content === "") {
             document.getElementById('data').value = "Fail to decrypt content - Do you have the key?";
-            return
-        } else {
-            content = decryptedcontent
-        }
+            return;
+        } 
     }
 
     if (type === '.html' || type == '.htm') {
@@ -398,7 +397,7 @@ function loadMarkdownRenderer() {
 }
 
 
-async function encryptdata(event){
+async function savedata(event){
     prev_fingerprint = curr_fingerprint;
     prev_hash = curr_hash
 
@@ -406,8 +405,8 @@ async function encryptdata(event){
     if (encryption.checked == true) {
         text = await encrypt(text)
         if (text === ''){
-            console.log("Fail to encrypt")
-            return
+            console.log("Fail to encrypt");
+            return;
         }
     }
 
@@ -417,7 +416,7 @@ async function encryptdata(event){
     save(text);
 }
 
-document.getElementById('data').addEventListener('input', (event) => encryptdata(event));
+document.getElementById('data').addEventListener('input', (event) => savedata(event));
 
 back.addEventListener('click', (event) => {
     load(prev_fingerprint, prev_hash);

--- a/index.html
+++ b/index.html
@@ -23,6 +23,19 @@
             font-family: ui-monospace, SFMono-Regular, SF Mono,Menlo, Consolas, Liberation Mono, monospace;
         }
 
+        .encryption{
+            position: absolute;
+            left: 0.5em;
+            top: 0.5em;
+            z-index: 1;
+            font-family: sans-serif;
+            background: #FFF;
+        }
+
+        .data{
+            margin-top: 2em
+        }
+
         textarea {
             outline: none;
             border: none;
@@ -85,11 +98,14 @@
 </head>
 <body>
 <a class="about" href="https://github.com/ClickHouse/pastila">About</a>
+<div class="encryption">
+<input id="encryption"  type="checkbox">AES Encryption</a>
+</div>
 <span class="status" id="hourglass">⧗</span>
 <span class="status" id="check-mark">✔</span>
 <span class="status" id="error">❌</span>
 <a class="status" id="back">⎌</a>
-<textarea id="data" spellcheck="false" autofocus></textarea>
+<textarea id="data" class="data" spellcheck="false" autofocus></textarea>
 <script type="text/javascript">
 
 const clickhouse_url = "https://play.clickhouse.com/?user=paste";
@@ -166,6 +182,7 @@ let curr_fingerprint = '';
 let curr_hash = '';
 let prev_fingerprint = '';
 let prev_hash = '';
+let anchorkey = window.location.hash.substring(1);
 
 let request_num = 0;
 
@@ -173,6 +190,7 @@ let back = document.getElementById('back');
 let check = document.getElementById('check-mark');
 let error = document.getElementById('error');
 let wait = document.getElementById('hourglass');
+let encryption = document.getElementById('encryption');
 
 function hide() {
     back.style.display = 'none';
@@ -184,6 +202,87 @@ function hide() {
 function show(what) {
     hide();
     what.style.display = 'block';
+}
+
+function b64EncodeUnicode(str) {
+    return btoa(encodeURIComponent(str).replace(/%([0-9A-F]{2})/g, function(match, p1) {
+        return String.fromCharCode('0x' + p1);
+    }));
+}
+
+function bytesToBase64(bytes) {
+  let binary = "";
+  let len = bytes.byteLength;
+  for (let i = 0; i < len; i++) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return window.btoa(binary);
+}
+
+function base64ToBytes(base64) {
+  let binary_string =  window.atob(base64);
+  let len = binary_string.length;
+  let bytes = new Uint8Array(len);
+  for (var i = 0; i < len; i++) {
+    bytes[i] = binary_string.charCodeAt(i);
+  }
+  return bytes;
+}
+
+async function decrypt(content){
+    try {
+        if (anchorkey == '') {
+            throw "No key was found - cannot decrypt"
+        }
+        let encryptedbytes=base64ToBytes(content.substr(4))
+        const encodedkey = new TextEncoder('utf8').encode(anchorkey)
+        pbkdf2_keymaterials = await window.crypto.subtle.importKey("raw", encodedkey, {name: "PBKDF2"}, false, ["deriveBits"]);
+        const salt = encryptedbytes.slice(8, 16);
+        let pbkdf2keybytes = await window.crypto.subtle.deriveBits({ "name": 'PBKDF2', "salt": salt, "iterations": 1000, "hash": 'SHA-256' }, pbkdf2_keymaterials, 384)
+        pbkdf2keybytes = new Uint8Array(pbkdf2keybytes);
+        const keybytes = pbkdf2keybytes.slice(0, 32);
+        const iv = pbkdf2keybytes.slice(32);
+        encryptedbytes = encryptedbytes.slice(16);
+        const aeskey = await window.crypto.subtle.importKey('raw', keybytes, { name: 'AES-CBC', length: 256 }, false, ['decrypt'])
+        let plaintextbytes = await window.crypto.subtle.decrypt({ name: "AES-CBC", iv: iv }, aeskey, encryptedbytes)
+        const result = new TextDecoder("utf-8").decode(plaintextbytes)
+        return result
+    } catch(e) {
+        console.log("Fail to decrypt - return content as is")
+        console.log(e)
+        return content
+    }
+}
+
+async function encrypt(content){
+    try {
+        if (anchorkey == '') {
+            anchorkey=([1e7]+-1e3+-4e3+-8e3+-1e11).replace(/[018]/g, c =>(c ^ crypto.getRandomValues(new Uint8Array(1))[0] & 15 >> c / 4).toString(16));
+        }
+        let plaintextbytes = new TextEncoder("utf-8").encode(content)
+        const encodedkey = new TextEncoder('utf8').encode(anchorkey)
+        pbkdf2_keymaterials = await window.crypto.subtle.importKey("raw", encodedkey, {name: "PBKDF2"}, false, ["deriveBits"]);
+        salt = window.crypto.getRandomValues(new Uint8Array(8));
+        let pbkdf2keybytes = await window.crypto.subtle.deriveBits({ "name": 'PBKDF2', "salt": salt, "iterations": 1000, "hash": 'SHA-256' }, pbkdf2_keymaterials, 384)
+        pbkdf2keybytes = new Uint8Array(pbkdf2keybytes);
+        const keybytes = pbkdf2keybytes.slice(0, 32);
+        const iv = pbkdf2keybytes.slice(32);
+        const aeskey = await window.crypto.subtle.importKey('raw', keybytes, { name: 'AES-CBC', length: 256 }, false, ['encrypt'])
+        let encryptedbytes = await window.crypto.subtle.encrypt({ name: "AES-CBC", iv: iv }, aeskey, plaintextbytes)
+        encryptedbytes = new Uint8Array(encryptedbytes);
+        let resultbytes = new Uint8Array(encryptedbytes.length + 16)
+        resultbytes.set(new TextEncoder("utf-8").encode('Salted__'));
+        resultbytes.set(salt, 8);
+        resultbytes.set(encryptedbytes, 16);
+        result = "Enc="+bytesToBase64(resultbytes)
+        return result
+
+    } catch (e) {
+        alert("Fail to encrypt - File not sent")
+        console.error(e);
+        return ""
+    }
+
 }
 
 async function load(fingerprint, hash, type) {
@@ -203,13 +302,24 @@ async function load(fingerprint, hash, type) {
     if (json.rows != 1) onError();
 
     const result = json.data[0];
-    const content = result.content;
+    let content = result.content;
 
     prev_hash = result.prev_hash;
     prev_fingerprint = result.prev_fingerprint;
 
     curr_hash = hash;
     curr_fingerprint = fingerprint;
+
+    if (content.startsWith("Enc=")) {
+        encryption.checked = true
+        decryptedcontent=await decrypt(content)
+        if (content === decryptedcontent) {
+            document.getElementById('data').value = "Fail to decrypt content - Do you have the key?";
+            return
+        } else {
+            content = decryptedcontent
+        }
+    }
 
     if (type === '.html' || type == '.htm') {
         document.open();
@@ -257,7 +367,7 @@ async function save(text) {
     }
 
     if (my_request_num == request_num) {
-        history.pushState(null, null, window.location.pathname.replace(/(\?.+)?$/, `?${curr_fingerprint}/${curr_hash}`));
+        history.pushState(null, null, window.location.pathname.replace(/(\?.+)?$/, `?${curr_fingerprint}/${curr_hash}#${anchorkey}`));
         show(check);
         setFavicon();
     }
@@ -288,22 +398,30 @@ function loadMarkdownRenderer() {
 }
 
 
-document.getElementById('data').addEventListener('input', (event) => {
-
+async function encryptdata(event){
     prev_fingerprint = curr_fingerprint;
     prev_hash = curr_hash
 
-    const text = document.getElementById('data').value;
+    let text = document.getElementById('data').value;
+    if (encryption.checked == true) {
+        text = await encrypt(text)
+        if (text === ''){
+            console.log("Fail to encrypt")
+            return
+        }
+    }
 
     curr_hash = sipHash128(encoder.encode(text));
     curr_fingerprint = getFingerprint(text);
 
     save(text);
-});
+}
+
+document.getElementById('data').addEventListener('input', (event) => encryptdata(event));
 
 back.addEventListener('click', (event) => {
     load(prev_fingerprint, prev_hash);
-    history.pushState(null, null, window.location.pathname.replace(/(\?.+)?$/, `?${curr_fingerprint}/${curr_hash}`));
+    history.pushState(null, null, window.location.pathname.replace(/(\?.+)?$/, `?${curr_fingerprint}/${curr_hash}#${anchorkey}`));
 });
 
 function restore() {


### PR DESCRIPTION
Simply adding encryption option for pastila. 

For encryption:
 - If encryption check boxed is enabled, either check for existing key in anchor tag or generate new key using uuidv4 algo with random number generator
 - derive key from anchortag key & random salt, then encrypt the data, add salt and insert back to ClickHouse
 
Decryption: 
 - If message receive from clickhouse starts with "Enc=" , decrypt the data using key drive from the [URI fragment](https://en.wikipedia.org/wiki/URI_fragment) (aka anchor tag) key and salt embedded in data receive from  ClickHouse
 - Display the content as per usual - this should not affect how html and markdown are handled
 
 Screenshot :

![CleanShot 2022-08-17 at 23 35 30](https://user-images.githubusercontent.com/3240146/185148205-5e3bd9d4-25c1-485b-88e1-5b91bfca0c6e.png)


Also... back button still works as per usual - Proof (Please replace with your local path) :

file:///path_to_pastila/index.html?2bc776ef/be9aa03dae29224a636fa2f95a1c0814#29783272-96c8-4d76-92e4-3b3c08302e0e

Without the key behind anchor tag, this should not work:
file:///path_to_pastila/index.html?2bc776ef/be9aa03dae29224a636fa2f95a1c0814

About the  [URI fragment](https://www.rfc-editor.org/rfc/rfc3986#page-24), all browsers do not forward this value back to server side and this was used by firefox-send as well as many other easy-to-use secure file transfer apps, we can further protect sensitive data by allowing user to add their own password in the future.