### PR TITLE
Fix recursion in Chrome

### DIFF
--- a/index.html
+++ b/index.html
@@ -251,7 +251,11 @@ async function decrypt(content, key) {
 }
 
 function bytesToBase64(bytes) {
-    return window.btoa(String.fromCharCode(...bytes));
+    let string = '';
+    for (let char of bytes) {
+        string += String.fromCharCode(char);
+    }
+    return window.btoa(string);
 }
 
 function base64ToBytes(base64) {

--- a/index.html
+++ b/index.html
@@ -252,7 +252,7 @@ async function decrypt(content, key) {
 
 function bytesToBase64(bytes) {
     let string = '';
-    for (let char of bytes) {
+    for (const char of bytes) {
         string += String.fromCharCode(char);
     }
     return window.btoa(string);


### PR DESCRIPTION
Chrome fails due to the recursion limit in functional-style JavaScript code.
Firefox is alright.