### PR TITLE
Adding vim plugin to save and load from pastila.nl

### DIFF
--- a/doc/pastila.txt
+++ b/doc/pastila.txt
@@ -1,0 +1,67 @@
+*pastila.txt*  Vim plugin for pastila.nl — encrypted paste service
+
+CONTENTS                                                    *pastila-contents*
+
+    1. Introduction .......................... |pastila-introduction|
+    2. Requirements .......................... |pastila-requirements|
+    3. Installation .......................... |pastila-installation|
+    4. Commands .............................. |pastila-commands|
+    5. Options ............................... |pastila-options|
+
+==============================================================================
+1. INTRODUCTION                                         *pastila-introduction*
+
+Pastila is a Vim plugin for uploading and downloading encrypted pastes
+via https://pastila.nl, a paste service powered by ClickHouse.
+
+All pastes are end-to-end encrypted by default. The encryption key is
+part of the URL fragment and never sent to the server.
+
+==============================================================================
+2. REQUIREMENTS                                         *pastila-requirements*
+
+- python3 in $PATH
+- Python `cryptography` package: >
+    pip install cryptography
+<
+
+==============================================================================
+3. INSTALLATION                                         *pastila-installation*
+
+Using a plugin manager (e.g. vim-plug): >
+    Plug 'ClickHouse/pastila'
+
+==============================================================================
+4. COMMANDS                                                *pastila-commands*
+
+                                                            *:PastilaUpload*
+:[range]PastilaUpload
+    Upload [range] lines (default: entire buffer) to pastila.nl.
+    The returned URL is copied to the system clipboard (|quoteplus|)
+    and echoed in the command line.
+
+    Examples: >
+        :PastilaUpload           " upload entire buffer
+        :'<,'>PastilaUpload      " upload visual selection
+        :10,20PastilaUpload      " upload lines 10-20
+<
+                                                          *:PastilaDownload*
+:PastilaDownload {url}
+    Download a paste by its full pastila URL (including the #key
+    fragment for encrypted pastes). Opens the content in a new
+    scratch buffer.
+
+    Example: >
+        :PastilaDownload https://pastila.nl/?abcd1234/deadbeef...#key
+<
+
+==============================================================================
+5. OPTIONS                                                  *pastila-options*
+
+                                                          *g:loaded_pastila*
+g:loaded_pastila
+    Set by the plugin after loading. Unlet it before re-sourcing
+    to reload the plugin (see |pastila-installation|).
+
+==============================================================================
+vim:tw=78:ft=help:norl:

--- a/pastila.py
+++ b/pastila.py
@@ -1,7 +1,16 @@
 #!/usr/bin/python3
-import sys, requests, json, re, base64, os
-from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+
+import base64
+import json
+import os
+import sys
+from random import randint
+from typing import List
+from urllib.parse import urlparse
+from urllib.request import Request, urlopen
+
 from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 
 #
 # Script to upload/download to/from pastila.nl from command line.
@@ -15,13 +24,13 @@ from cryptography.hazmat.backends import default_backend
 #
 
 
-def sipHash128(m: bytes):
+def sipHash128(m: bytes) -> str:
     mask = (1 << 64) - 1
-    
-    def rotl(v, offset, bits):
+
+    def rotl(v: List[int], offset: int, bits: int) -> None:
         v[offset] = ((v[offset] << bits) & mask) | ((v[offset] & mask) >> (64 - bits))
 
-    def compress(v):
+    def compress(v: List[int]) -> None:
         v[0] += v[1]
         v[2] += v[3]
         rotl(v, 1, 13)
@@ -37,10 +46,10 @@ def sipHash128(m: bytes):
         v[3] ^= v[0]
         rotl(v, 2, 32)
 
-    v = [0x736f6d6570736575, 0x646f72616e646f6d, 0x6c7967656e657261, 0x7465646279746573]
+    v = [0x736F6D6570736575, 0x646F72616E646F6D, 0x6C7967656E657261, 0x7465646279746573]
     offset = 0
     while offset < len(m) - 7:
-        word = int.from_bytes(m[offset:offset + 8], 'little')
+        word = int.from_bytes(m[offset : offset + 8], "little")
         v[3] ^= word
         compress(v)
         compress(v)
@@ -48,10 +57,10 @@ def sipHash128(m: bytes):
         offset += 8
 
     buf = bytearray(8)
-    buf[:len(m) - offset] = m[offset:]
-    buf[7] = len(m) & 0xff
+    buf[: len(m) - offset] = m[offset:]
+    buf[7] = len(m) & 0xFF
 
-    word = int.from_bytes(buf, 'little')
+    word = int.from_bytes(buf, "little")
     v[3] ^= word
     compress(v)
     compress(v)
@@ -63,79 +72,108 @@ def sipHash128(m: bytes):
     compress(v)
 
     hash_val = ((v[0] ^ v[1]) & mask) + (((v[2] ^ v[3]) & mask) << 64)
-    s = '{:032x}'.format(hash_val)
-    return ''.join(s[i:i+2] for i in range(30,-2,-2))
+    s = f"{hash_val:032x}"
+    return "".join(s[i : i + 2] for i in range(30, -2, -2))
 
-def error(s):
+
+def error(s: str) -> None:
     sys.stderr.write(f"error: {s}\n")
     sys.exit(1)
 
-# This is too slow, and doesn't seem important.
-#def getFingerprint(text):
-#    words = re.findall(r'\b\w{4,}\b', text.decode()) # doesn't exactly match the JS code, but it doesn't have to
-#    triplets = [''.join(words[i:i+3]) for i in range(len(words) - 2)]
-#    uniq = set(triplets)
-#    hashes = [sipHash128(s.encode())[:8] for s in uniq]
-#    hashes.append('ffffffff')
-#    return min(hashes)
 
-def load(url):
-    r = re.match(r"^(?:(?:(?:(?:(?:https?:)?//)?pastila\.nl)?/)?\?)?([a-f0-9]+)/([a-f0-9]+)(?:#(.+))?$", url)
-    if r is None: error('bad url')
-    fingerprint, hash_hex, key = r.groups()
+def load(url: str) -> bytes:
+    parsed = urlparse(url)
+    fingerprint, hash_hex = parsed.query.split("/", maxsplit=1)
+    hash_hex = hash_hex.split(".", maxsplit=1)[0]  # for .diff, .md etc
+    key = parsed.fragment
+    if not (fingerprint and hash_hex and key):
+        error(f"invalid url: {url}")
 
-    response = requests.post('https://uzg8q0g12h.eu-central-1.aws.clickhouse.cloud/?user=paste', data=f"SELECT content, is_encrypted FROM data_view(fingerprint = '{fingerprint}', hash = '{hash_hex}') FORMAT JSON")
-    if not response.ok: error(f"{response} {response.content}")
+    query = (
+        "SELECT content, is_encrypted FROM "
+        f"data_view(fingerprint = '{fingerprint}', hash = '{hash_hex}') FORMAT JSON"
+    )
 
-    j = json.loads(response.content)
-    if j['rows'] != 1: error("paste not found")
-    #if 'statistics' in j: sys.stderr.write(f"{j['statistics']}")
-    content, is_encrypted = j['data'][0]['content'], j['data'][0]['is_encrypted']
+    req = Request(
+        "https://uzg8q0g12h.eu-central-1.aws.clickhouse.cloud/?user=paste",
+        data=query.encode("utf-8"),
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+        method="POST",
+    )
+    try:
+        with urlopen(req) as response:
+            body = response.read().decode("utf-8")
+    except Exception as e:
+        error(f"failed to fetch paste: {e}")
 
-    if is_encrypted:
-        if key is None: error("paste is encrypted, but the url contains no key (part after '#')")
-        key = base64.b64decode(key)
-        content = base64.b64decode(content)
-        cipher = Cipher(algorithms.AES(key), modes.CTR(b'\x00' * 16), backend=default_backend())
-        decryptor = cipher.decryptor()
-        decrypted = decryptor.update(content) + decryptor.finalize()
-        content = decrypted
+    j = json.loads(body)
+    if j["rows"] != 1:
+        error("paste not found")
+    # if 'statistics' in j: sys.stderr.write(f"{j['statistics']}")
+    content, is_encrypted = (
+        j["data"][0]["content"],
+        j["data"][0]["is_encrypted"],
+    )  # type: str, int
 
-    return content
+    if not is_encrypted:
+        return content.encode("utf-8")
 
-def save(data, encrypt):
+    decoded = base64.b64decode(content)
+    cipher = Cipher(
+        algorithms.AES(base64.b64decode(key.encode("utf-8"))),
+        modes.CTR(b"\x00" * 16),
+        backend=default_backend(),
+    )
+    decryptor = cipher.decryptor()
+    decrypted = decryptor.update(decoded) + decryptor.finalize()
+    return decrypted
+
+
+def save(data: bytes) -> str:
     key = os.urandom(16)
     url_suffix = ""
-    if encrypt:
-        cipher = Cipher(algorithms.AES(key), modes.CTR(b'\x00' * 16), backend=default_backend())
-        encryptor = cipher.encryptor()
-        encrypted = encryptor.update(data) + encryptor.finalize()
-        data = base64.b64encode(encrypted)
-        url_suffix = '#' + base64.b64encode(key).decode()
+    cipher = Cipher(
+        algorithms.AES(key), modes.CTR(b"\x00" * 16), backend=default_backend()
+    )
+    encryptor = cipher.encryptor()
+    encrypted = encryptor.update(data) + encryptor.finalize()
+    data = base64.b64encode(encrypted)
+    url_suffix = "#" + base64.b64encode(key).decode()
 
     h = sipHash128(data)
-    fingerprint = 'cafebabe' # getFingerprint(data)
+    fingerprint = f"{randint(0, 0xFFFFFFFF):08x}"
 
-    payload = json.dumps({
-        'fingerprint_hex': fingerprint,
-        'hash_hex': h,
-        'content': data.decode(),
-        'is_encrypted': encrypt,
-    })
-    response = requests.post('https://uzg8q0g12h.eu-central-1.aws.clickhouse.cloud/?user=paste', data=f'INSERT INTO data (fingerprint_hex, hash_hex, content, is_encrypted) FORMAT JSONEachRow {payload}')
-    if not response.ok: error(f"{response} {response.content}")
-    print(f"https://pastila.nl/?{fingerprint}/{h}{url_suffix}")
+    payload = json.dumps(
+        {
+            "fingerprint_hex": fingerprint,
+            "hash_hex": h,
+            "content": data.decode(),
+            "is_encrypted": 1,
+        }
+    )
+    req = Request(
+        "https://uzg8q0g12h.eu-central-1.aws.clickhouse.cloud/?user=paste",
+        data="INSERT INTO data (fingerprint_hex, hash_hex, content, is_encrypted) "
+        f"FORMAT JSONEachRow {payload}".encode("utf-8"),
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+        method="POST",
+    )
+    try:
+        with urlopen(req):
+            pass
+    except Exception as e:
+        error(f"failed to save paste: {e}")
+
+    return f"https://pastila.nl/?{fingerprint}/{h}{url_suffix}"
 
 
-if len(sys.argv) == 1:
-    data = sys.stdin.buffer.read()
-    save(data, True)
-elif len(sys.argv) == 2 and sys.argv[1] == 'plain':
-    data = sys.stdin.buffer.read()
-    save(data, False)
-elif len(sys.argv) == 2:
-    data = load(sys.argv[1])
-    sys.stdout.buffer.write(data)
-else:
-    print("usage: pastila.py [url]")
-    sys.exit(1)
+if __name__ == "__main__":
+    if len(sys.argv) == 1:
+        data = sys.stdin.buffer.read()
+        print(save(data))
+    elif len(sys.argv) == 2:
+        data = load(sys.argv[1])
+        sys.stdout.buffer.write(data)
+    else:
+        print("usage: pastila.py [url]")
+        sys.exit(1)

--- a/pastila.py
+++ b/pastila.py
@@ -93,7 +93,7 @@ def load(url: str) -> bytes:
         error(f"invalid url: {url}")
     hash_hex = hash_hex.split(".", maxsplit=1)[0]  # for .diff, .md etc
     key = parsed.fragment
-    if not (is_valid_hex(fingerprint) and is_valid_hex(hash_hex) and key):
+    if not (is_valid_hex(fingerprint) and is_valid_hex(hash_hex)):
         error(f"invalid url: {url}")
 
     query = (
@@ -125,6 +125,8 @@ def load(url: str) -> bytes:
     if not is_encrypted:
         return content.encode("utf-8")
 
+    if not key:
+        error("paste is encrypted, but no key provided in the URL")
     decoded = base64.b64decode(content)
     cipher = Cipher(
         algorithms.AES(base64.b64decode(key)),

--- a/pastila.py
+++ b/pastila.py
@@ -196,7 +196,7 @@ def parse_args() -> argparse.Namespace:
         "pastila_url",
         nargs="?",
         help="Full pastila URL to download the data. "
-        "When given, the script post content to stdout.",
+        "When given, the script posts content to stdout.",
     )
     return parser.parse_args()
 

--- a/pastila.py
+++ b/pastila.py
@@ -1,5 +1,6 @@
 #!/usr/bin/python3
 
+import argparse
 import base64
 import json
 import os
@@ -85,7 +86,7 @@ def error(s: str) -> None:
     sys.exit(1)
 
 
-def load(url: str) -> bytes:
+def load(url: str, clickhouse_url: str) -> bytes:
     parsed = urlparse(url)
     try:
         fingerprint, hash_hex = parsed.query.split("/", maxsplit=1)
@@ -102,7 +103,7 @@ def load(url: str) -> bytes:
     )
 
     req = Request(
-        "https://uzg8q0g12h.eu-central-1.aws.clickhouse.cloud/?user=paste",
+        clickhouse_url,
         data=query.encode("utf-8"),
         headers={"Content-Type": "application/x-www-form-urlencoded"},
         method="POST",
@@ -116,7 +117,7 @@ def load(url: str) -> bytes:
     j = json.loads(body)
     if j["rows"] != 1:
         error("paste not found")
-    # if 'statistics' in j: sys.stderr.write(f"{j['statistics']}")
+
     content, is_encrypted = (
         j["data"][0]["content"],
         j["data"][0]["is_encrypted"],
@@ -138,7 +139,7 @@ def load(url: str) -> bytes:
     return decrypted
 
 
-def save(data: bytes) -> str:
+def save(data: bytes, pastila_prefix: str, clickhouse_url: str) -> str:
     key = os.urandom(16)
     url_suffix = ""
     cipher = Cipher(
@@ -161,7 +162,7 @@ def save(data: bytes) -> str:
         }
     )
     req = Request(
-        "https://uzg8q0g12h.eu-central-1.aws.clickhouse.cloud/?user=paste",
+        clickhouse_url,
         data="INSERT INTO data (fingerprint_hex, hash_hex, content, is_encrypted) "
         f"FORMAT JSONEachRow {payload}".encode("utf-8"),
         headers={"Content-Type": "application/x-www-form-urlencoded"},
@@ -173,16 +174,39 @@ def save(data: bytes) -> str:
     except Exception as e:
         error(f"failed to save paste: {e}")
 
-    return f"https://pastila.nl/?{fingerprint}/{h}{url_suffix}"
+    return f"{pastila_prefix}?{fingerprint}/{h}{url_suffix}"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Upload to or download from pastila.nl",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument(
+        "--pastila-prefix",
+        help="Hostname URL to use when uploading",
+        default="https://pastila.nl/",
+    )
+    parser.add_argument(
+        "--clickhouse-url",
+        help="ClickHouse URL to query the data table",
+        default="https://uzg8q0g12h.eu-central-1.aws.clickhouse.cloud/?user=paste",
+    )
+    parser.add_argument(
+        "pastila_url",
+        nargs="?",
+        help="Full pastila URL to download the data. "
+        "When given, the script post content to stdout.",
+    )
+    return parser.parse_args()
 
 
 if __name__ == "__main__":
-    if len(sys.argv) == 1:
-        data = sys.stdin.buffer.read()
-        print(save(data))
-    elif len(sys.argv) == 2:
-        data = load(sys.argv[1])
+    args = parse_args()
+    if args.pastila_url:
+        data = load(args.pastila_url, args.clickhouse_url)
         sys.stdout.buffer.write(data)
-    else:
-        print("usage: pastila.py [url]")
-        sys.exit(1)
+        sys.exit(0)
+
+    data = sys.stdin.buffer.read()
+    print(save(data, args.pastila_prefix, args.clickhouse_url))

--- a/plugin/pastila.vim
+++ b/plugin/pastila.vim
@@ -27,8 +27,12 @@ function! s:PastilaUpload() range
         echohl None
     else
         let l:url = substitute(l:output, '[\r\n]\+$', '', '')
-        let @+ = l:url
-        echo 'Pastila: ' . l:url . ' (copied to clipboard)'
+        if has('clipboard') || has('unnamedplus')
+            let @+ = l:url
+            echo 'Pastila: ' . l:url . ' (copied to clipboard)'
+        else
+            echo 'Pastila: ' . l:url
+        endif
     endif
 endfunction
 

--- a/plugin/pastila.vim
+++ b/plugin/pastila.vim
@@ -1,0 +1,51 @@
+" plugin/pastila.vim — Vim plugin for pastila.nl
+
+if exists('g:loaded_pastila')
+    finish
+endif
+let g:loaded_pastila = 1
+
+let s:script_dir = fnamemodify(resolve(expand('<sfile>:p')), ':h:h')
+let s:pastila_py = s:script_dir . '/pastila.py'
+
+function! s:LineEnding(ff)
+    if a:ff ==# 'dos'
+        return "\r\n"
+    elseif a:ff ==# 'mac'
+        return "\r"
+    endif
+    return "\n"
+endfunction
+
+function! s:PastilaUpload() range
+    let l:eol = s:LineEnding(&fileformat)
+    let l:lines = join(getline(a:firstline, a:lastline), l:eol) . l:eol
+    let l:output = system('python3 ' . shellescape(s:pastila_py), l:lines)
+    if v:shell_error
+        echohl ErrorMsg
+        echom 'Pastila upload failed: ' . l:output
+        echohl None
+    else
+        let l:url = substitute(l:output, '[\r\n]\+$', '', '')
+        let @+ = l:url
+        echo 'Pastila: ' . l:url . ' (copied to clipboard)'
+    endif
+endfunction
+
+function! s:PastilaDownload(url)
+    let l:output = system('python3 ' . shellescape(s:pastila_py) . ' ' . shellescape(a:url))
+    if v:shell_error
+        echohl ErrorMsg
+        echom 'Pastila download failed: ' . l:output
+        echohl None
+    else
+        new
+        setlocal buftype=nofile bufhidden=wipe noswapfile
+        put! =l:output
+        " Remove trailing empty line left by put
+        $delete _
+    endif
+endfunction
+
+command! -range=% PastilaUpload <line1>,<line2>call s:PastilaUpload()
+command! -nargs=1 PastilaDownload call s:PastilaDownload(<q-args>)


### PR DESCRIPTION
- Refactor the Python script a little bit to use type hinting and argparse
- Add vim plugin supporting `PastilaUpload` and `PastilaDownload` commands:
    - `PastilaUpload` supports range, uploading the whole buffer by default
    - `PastilaDownload` opens a new buffer with the downloaded content