### PR TITLE
Add a 'share' skill to share a Claude session to pastila

### DIFF
--- a/.claude/skills/share/SKILL.md
+++ b/.claude/skills/share/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: share
+description: Share a Claude Code session to pastila.nl and return a viewer link. Shares the current session by default, or a session specified as a transcript path, a session id, or a project. Use when the user asks to share, publish, or get a link to this conversation or to a session/transcript.
+argument-hint: "[session: path | session-id | project]"
+disable-model-invocation: false
+allowed-tools: Bash
+---
+
+# Share a Claude session
+
+Upload a Claude Code session transcript to pastila.nl (encrypted) and return a
+`.claude.jsonl` link that renders it like the viewer at
+https://github.com/ClickHouse/alexeyprompts
+
+## Steps
+
+1. Run the bundled helper. It lives in the same directory as this SKILL.md — use
+   its absolute path (when working in the pastila repo this is
+   `.claude/skills/share/share.py`):
+
+   ```sh
+   python3 <skill-dir>/share.py [session]
+   ```
+
+   - **No argument** → shares the **current** session (identified by
+     `$CLAUDE_CODE_SESSION_ID`).
+   - **`[session]`** → shares another session, given as one of:
+     - a path to a `.jsonl` transcript,
+     - a session id (uuid), or
+     - a project path or its `~/.claude/projects` directory name (shares the
+       newest session in it).
+
+2. Report the URL the script prints to the user.
+
+The script delegates the upload to `pastila.py` (encryption + INSERT), so that
+logic is not duplicated; it then inserts the `.claude.jsonl` extension before the
+`#` key anchor to produce the viewer link.
+
+## Notes
+
+- The link contains the decryption key in its `#` fragment — anyone with the link
+  can read the session. Share it only intentionally.
+- Sessions include tool calls and results (file fragments, command output). Take a
+  quick look before sharing potentially sensitive ones.
+- Requires `pastila.py` (found in the pastila repo, the current directory, or on
+  `PATH`) and its dependencies (`requests`, `cryptography`).

--- a/.claude/skills/share/share.py
+++ b/.claude/skills/share/share.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""
+Share a Claude Code session to pastila.nl and print a `.claude.jsonl` viewer link.
+
+By default it shares the *current* session (the one running this skill, identified
+by $CLAUDE_CODE_SESSION_ID). An explicit session may be passed as the first
+argument, given as any of:
+  - a path to a .jsonl transcript file,
+  - a session id (uuid),
+  - a project path or its ~/.claude/projects directory name (newest session there).
+
+The actual upload (encryption + INSERT) is delegated to pastila.py, so none of
+that logic is duplicated here -- this script only locates the transcript, runs
+pastila.py on it, and turns the resulting paste URL into a session-viewer URL by
+inserting the `.claude.jsonl` extension before the `#` key anchor.
+"""
+
+import os
+import re
+import sys
+import glob
+import shutil
+import subprocess
+from pathlib import Path
+
+PROJECTS = Path.home() / ".claude" / "projects"
+
+
+def die(msg):
+    sys.stderr.write("share: " + msg + "\n")
+    sys.exit(1)
+
+
+def encode(path):
+    # Claude Code names a project's transcript directory after its path with every
+    # non-alphanumeric character replaced by '-' (e.g. /home/u/p -> -home-u-p).
+    return re.sub(r"[^A-Za-z0-9]", "-", path)
+
+
+def newest(paths):
+    paths = [p for p in paths if Path(p).name != "history.jsonl"]
+    if not paths:
+        return None
+    return Path(max(paths, key=lambda p: Path(p).stat().st_mtime))
+
+
+def newest_in_dir(d):
+    return newest(glob.glob(str(Path(d) / "*.jsonl")))
+
+
+def resolve_session(arg):
+    """Return the Path of the transcript to share."""
+    if arg:
+        p = Path(arg).expanduser()
+        if p.is_file():
+            return p
+        # A bare session id (uuid): look it up across all projects.
+        if "/" not in arg and not arg.endswith(".jsonl"):
+            matches = glob.glob(str(PROJECTS / "*" / (arg + ".jsonl")))
+            if matches:
+                return Path(matches[0])
+        # A project: either a ~/.claude/projects subdirectory name, or a project
+        # path that needs encoding. Share the newest session found in it.
+        for cand in (PROJECTS / arg, PROJECTS / encode(arg),
+                     PROJECTS / encode(str(p if p.is_absolute() else p.resolve()))):
+            if cand.is_dir():
+                n = newest_in_dir(cand)
+                if n:
+                    return n
+        die("could not resolve a session from %r" % arg)
+
+    # No argument: the current session, identified by its id.
+    sid = os.environ.get("CLAUDE_CODE_SESSION_ID")
+    if sid:
+        matches = glob.glob(str(PROJECTS / "*" / (sid + ".jsonl")))
+        if matches:
+            return Path(matches[0])
+
+    # Fallbacks: newest session in the current project's directory, then newest
+    # session anywhere.
+    n = newest_in_dir(PROJECTS / encode(os.getcwd()))
+    if n:
+        return n
+    n = newest(glob.glob(str(PROJECTS / "*" / "*.jsonl")))
+    if n:
+        return n
+    die("no session transcript found under " + str(PROJECTS))
+
+
+def find_pastila():
+    candidates = [
+        Path(__file__).resolve().parents[3] / "pastila.py",  # the pastila repo
+        Path(__file__).resolve().parent / "pastila.py",      # copied next to this script
+        Path.cwd() / "pastila.py",
+    ]
+    on_path = shutil.which("pastila.py")
+    if on_path:
+        candidates.append(Path(on_path))
+    for c in candidates:
+        if c.is_file():
+            return c
+    die("cannot find pastila.py (looked in the pastila repo, this skill's "
+        "directory, the current directory, and PATH)")
+
+
+def to_view_url(url):
+    # Turn .../?fp/hash#key into .../?fp/hash.claude.jsonl#key
+    if "#" in url:
+        base, frag = url.split("#", 1)
+        return base + ".claude.jsonl#" + frag
+    return url + ".claude.jsonl"
+
+
+def main():
+    arg = sys.argv[1] if len(sys.argv) > 1 else None
+    session = resolve_session(arg)
+    pastila = find_pastila()
+
+    data = session.read_bytes()
+    proc = subprocess.run([sys.executable, str(pastila)], input=data,
+                          stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    if proc.returncode != 0:
+        die("upload failed: " + (proc.stderr.decode(errors="replace").strip() or
+                                 "pastila.py exited with %d" % proc.returncode))
+
+    url = proc.stdout.decode().strip()
+    if not url.startswith("http"):
+        die("unexpected pastila.py output: " + url)
+
+    print(to_view_url(url))
+    sys.stderr.write("shared %s (%d bytes)\n" % (session, len(data)))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds a Claude Code skill, `share`, that uploads a session transcript to pastila.nl and returns a `.claude.jsonl` viewer link (rendered like https://github.com/ClickHouse/alexeyprompts).

## Usage
`/share` — shares the **current** session (found via `$CLAUDE_CODE_SESSION_ID`).
`/share <session>` — shares another session, given as a transcript path, a session id (uuid), or a project path / `~/.claude/projects` dir name (newest session in it).

## Design
- `.claude/skills/share/SKILL.md` — skill definition + instructions.
- `.claude/skills/share/share.py` — locates the transcript, then **delegates the upload (encryption + INSERT) to `pastila.py`** so none of that logic is duplicated, and finally inserts `.claude.jsonl` before the `#` key anchor to form the viewer link. It finds `pastila.py` in the repo, the cwd, or on `PATH`.

## Testing
- Session resolution verified for: current session (by id), explicit session id, and project dir name.
- Full end-to-end run uploaded the current session and produced a well-formed link; downloading it back via `pastila.py` decrypted to the exact source bytes.

Note: the link carries the decryption key in its `#` fragment, and sessions contain tool output / file fragments — the skill reminds the user to share intentionally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)