### PR TITLE
Count answers to agent questions in the cumulative User metric

### DIFF
--- a/session.html
+++ b/session.html
@@ -813,7 +813,8 @@ function buildCumulativeMetrics() {
         }
         if (msg.type === 'user') {
             const cl = classifyMessage(msg);
-            if (cl.category === 'user') userPrompts++;
+            // Answers to agent questions are user input too; count them like the User filter does.
+            if (cl.category === 'user' || cl.category === 'question_answer') userPrompts++;
             if (cl.category === 'plan') plans++;
         }
 


### PR DESCRIPTION
Follow-up to #51.

`countMessages` and the User filter already treat `question_answer` messages (answers to the `AskUserQuestion` tool) as user input, but the running **User** count in `buildCumulativeMetrics` — shown in the scroll-position metrics — still counted only the `user` category. So that count undercounted sessions containing answers to agent questions, inconsistent with the filter label.

Count `question_answer` there too.

Related: https://github.com/ClickHouse/pastila/pull/51

🤖 Generated with [Claude Code](https://claude.com/claude-code)